### PR TITLE
Fix CI runs on PRs

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -11,6 +11,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
       
       - name: Cache golang modules
         uses: actions/cache@v2


### PR DESCRIPTION
Checkout action does not fetch all history by default, so the diff was failing to locate the commit to compare against.